### PR TITLE
feat(proposers): add proposers page on the cvorum route

### DIFF
--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -11,6 +11,7 @@ import { getAccountData } from 'apiCalls/accountCalls';
 import { getEconomicsData } from 'apiCalls/economicsCalls';
 import { getUserMultisigContractsList } from 'apiCalls/multisigContractsCalls';
 import { uniqueContractAddress, uniqueContractName } from 'multisigConfig';
+import ProposersTable from 'pages/Organization/ProposersTable';
 import { setAccountData } from 'redux/slices/accountSlice';
 import { setEconomics } from 'redux/slices/economicsSlice';
 import { setMultisigContracts } from 'redux/slices/multisigContractsSlice';
@@ -81,34 +82,29 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
   }
 
   return (
-    <div
-      style={{ display: 'none !important' }}
-      className='bg-light d-flex flex-row flex-fill wrapper'
-    >
-      <Navbar />
-
-      <main
-        style={{ background: '#F4F6FD' }}
-        className='d-flex flex-row flex-fill position-relative justify-center  container'
+    <>
+      <div
+        style={{ display: 'none !important' }}
+        className='bg-light d-flex flex-row flex-fill wrapper'
       >
-        <AuthenticatedRoutesWrapper
-          routes={routes}
-          unlockRoute={routeNames.unlock}
+        <Navbar />
+
+        <main
+          style={{ background: '#F4F6FD' }}
+          className='d-flex flex-row flex-fill position-relative justify-center  container'
         >
-          {children}
-        </AuthenticatedRoutesWrapper>
-        <TokenWrapper />
-        <ModalLayer />
-        <SidebarSelectOptionModal />
-      </main>
-    </div>
-    // {/* <OrganizationInfoContextProvider>
-    //   <Organization />
-    //   <OrganizationTokens />
-    //   <NewDashboard />
-    //   <AssetsPage />
-    //   <TransactionsPage />
-    // </OrganizationInfoContextProvider> */}
+          <AuthenticatedRoutesWrapper
+            routes={routes}
+            unlockRoute={routeNames.unlock}
+          >
+            {children}
+          </AuthenticatedRoutesWrapper>
+          <TokenWrapper />
+          <ModalLayer />
+          <SidebarSelectOptionModal />
+        </main>
+      </div>
+    </>
   );
 };
 

--- a/src/pages/Organization/CvorumContainer.tsx
+++ b/src/pages/Organization/CvorumContainer.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Card, Grid } from '@mui/material';
+import ProposersTable from './ProposersTable';
+
+const CvorumContainer = () => {
+  return (
+    <Grid
+      direction='column'
+      container
+      className='shadow overflow-hidden p-5 rounded '
+    >
+      <Card className='px-4 py-5 mt-5'>
+        <div className='mb-4'>
+          <h2>Proposers</h2>
+        </div>
+        <ProposersTable />
+      </Card>
+    </Grid>
+  );
+};
+
+export default CvorumContainer;

--- a/src/pages/Organization/OwnershipDistribution.tsx
+++ b/src/pages/Organization/OwnershipDistribution.tsx
@@ -4,22 +4,22 @@ import MultiColorProgressBar from './MultiColorProgressBar';
 const OwnershipDistribution = () => {
   const readings = [
     {
-      name: 'Apples',
+      name: 'Owner1',
       value: 60,
       color: '#eb4d4b'
     },
     {
-      name: 'Blueberries',
+      name: 'Owner2',
       value: 7,
       color: '#22a6b3'
     },
     {
-      name: 'Guavas',
+      name: 'Owner3',
       value: 23,
       color: '#6ab04c'
     },
     {
-      name: 'Grapes',
+      name: 'Owner4',
       value: 10,
       color: '#e056fd'
     }

--- a/src/pages/Organization/ProposersTable.tsx
+++ b/src/pages/Organization/ProposersTable.tsx
@@ -1,0 +1,157 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Address } from '@elrondnetwork/erdjs/out';
+import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
+import ToggleOnIcon from '@mui/icons-material/ToggleOn';
+import { Box } from '@mui/material';
+import {
+  GridRowId,
+  GridActionsCellItem,
+  DataGrid,
+  GridRenderCellParams
+} from '@mui/x-data-grid';
+import { useDispatch } from 'react-redux';
+import { queryProposerAddresses } from 'contracts/MultisigContract';
+import { setProposeModalSelectedOption } from 'redux/slices/modalsSlice';
+import { ProposalsTypes } from 'types/Proposals';
+import { truncateInTheMiddle } from 'utils/addressUtils';
+
+type ProposerTableRow = Address & { id: number; role: string };
+
+const ProposersTable = () => {
+  const dispatch = useDispatch();
+  const onRemoveUser = (address: string) => {
+    return dispatch(
+      setProposeModalSelectedOption({
+        option: ProposalsTypes.remove_user,
+        address
+      })
+    );
+  };
+
+  const toggleAdmin = useCallback(
+    (id: GridRowId) => () => {
+      // setRows((prevRows) =>
+      //   prevRows.map((row) =>
+      //     row.id === id ? { ...row, isAdmin: !row.isAdmin } : row
+      //   )
+      // );
+    },
+    []
+  );
+
+  const duplicateUser = useCallback(
+    (id: GridRowId) => () => {
+      // setRows((prevRows) => {
+      //   const rowToDuplicate = prevRows.find((row) => row.id === id)!;
+      //   return [...prevRows, { ...rowToDuplicate, id: Date.now() }];
+      // });
+    },
+    []
+  );
+
+  const columns = useMemo(
+    () => [
+      {
+        field: 'valueHex',
+        headerName: 'Member',
+        type: 'string',
+        width: 350,
+        renderCell: (params: GridRenderCellParams<any>) => (
+          <div className='d-flex align-items-center'>
+            <img
+              className='mr-3 rounded w-100 h-100'
+              src='https://picsum.photos/30/30?random=1'
+            />
+            <div>
+              <div>
+                {truncateInTheMiddle(new Address(params.value).bech32(), 10)}
+              </div>
+              <div>@herotag</div>
+            </div>
+          </div>
+        )
+      },
+      {
+        field: 'role',
+        headerName: 'Role',
+        type: 'string',
+        width: 200,
+        renderCell: (params: GridRenderCellParams<any>) => (
+          <div
+            className='p-2 rounded'
+            style={
+              params.value === 'Board Member'
+                ? { background: 'rgba(255,0,0, 0.1)', color: 'red' }
+                : { background: 'rgba(0,255,0, 0.1)', color: 'green' }
+            }
+          >
+            {params.value}
+          </div>
+        )
+      },
+      {
+        field: 'actions',
+        type: 'actions',
+        width: 300,
+        headerName: 'Quick Actions',
+        getActions: (params: any) => [
+          // eslint-disable-next-line react/jsx-key
+          <div className='shadow-sm p-2 rounded mr-2'>
+            <GridActionsCellItem
+              icon={<ToggleOnIcon htmlColor='#9DABBD' />}
+              label='Toggle Admin'
+              onClick={toggleAdmin(params.id)}
+            />
+          </div>,
+          // eslint-disable-next-line react/jsx-key
+          <div className='shadow-sm p-2 rounded mr-2'>
+            <GridActionsCellItem
+              icon={<EditIcon htmlColor='#9DABBD' />}
+              label='Disable User'
+              onClick={duplicateUser(params.id)}
+            />
+          </div>,
+          // eslint-disable-next-line react/jsx-key
+          <div className='shadow-sm p-2 rounded mr-2'>
+            <GridActionsCellItem
+              icon={<DeleteIcon htmlColor='#9DABBD' />}
+              label='Delete'
+              onClick={() =>
+                onRemoveUser(new Address(params.row.valueHex).bech32())
+              }
+            />
+          </div>
+        ]
+      }
+    ],
+    [onRemoveUser, toggleAdmin, duplicateUser]
+  );
+
+  const [allProposers, setAllProposers] = useState([] as ProposerTableRow[]);
+
+  useEffect(() => {
+    (async function fetchProposers() {
+      const proposerAddresses = await queryProposerAddresses();
+      const proposersWithIndexes = proposerAddresses.map((item, idx) => ({
+        ...item,
+        role: 'Proposer',
+        id: idx
+      }));
+      setAllProposers(proposersWithIndexes as ProposerTableRow[]);
+    })();
+  }, []);
+
+  return (
+    <Box className='w-100'>
+      <DataGrid
+        autoHeight
+        rowHeight={65}
+        rows={allProposers ?? []}
+        columns={columns}
+      />
+    </Box>
+  );
+};
+
+export default ProposersTable;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -4,7 +4,9 @@ import { dAppName } from 'config';
 import AssetsPage from 'pages/AssetsPage/AssetsPage';
 import Decisions from 'pages/Decisions';
 import Organization from 'pages/Organization';
+import CvorumContainer from 'pages/Organization/CvorumContainer';
 import OrganizationTokens from 'pages/Organization/OrganizationTokens';
+import ProposersTable from 'pages/Organization/ProposersTable';
 import TransactionsPage from 'pages/Transactions/TransactionsPage';
 import Unlock from 'pages/Unlock';
 import withPageTitle from './components/PageTitle';
@@ -26,6 +28,8 @@ export type ForegroundRoutesType =
   | 'organization'
   | 'organizationTokens'
   | 'assets'
+  | 'cvorum'
+  | 'owners'
   | 'transactions';
 export type ModalRoutesType = 'walletconnect' | 'ledger';
 
@@ -71,7 +75,7 @@ export const foregroundRoutes: Record<ForegroundRoutesType, RouteType> = {
     component: Unlock
   },
   organization: {
-    path: '/organization',
+    path: '/organization-details',
     title: 'Organization',
     component: Organization
   },
@@ -89,6 +93,16 @@ export const foregroundRoutes: Record<ForegroundRoutesType, RouteType> = {
     path: '/transactions',
     title: 'Transactions',
     component: TransactionsPage
+  },
+  cvorum: {
+    path: '/cvorum',
+    title: 'Cvorum',
+    component: CvorumContainer
+  },
+  owners: {
+    path: '/owners',
+    title: 'Owners',
+    component: OrganizationTokens
   }
 };
 


### PR DESCRIPTION
What has changed: 
1. Organization details link from the sidebar points to the Organization component
2. Owners link from the sidebar points to the OrganizationTokens component (the mock for the holders and percentages) 
3. Cvorum link from the sidenar points to a new page/component with the Proposers shown in the table (quick actions that work: only delete user for now (there is no remove proposer action available afaik).