### PR TITLE
feat(loginFlow): implement M.Exchange like login flow

### DIFF
--- a/src/assets/sass/pages/unlock.scss
+++ b/src/assets/sass/pages/unlock.scss
@@ -16,8 +16,6 @@
   }
   .unlock {
     width: 100%;
-    max-width: toRem(366);
-    padding: 13px 20px;
     > a {
       color: #000 !important;
     }

--- a/src/components/Layout/Navbar/Account/index.tsx
+++ b/src/components/Layout/Navbar/Account/index.tsx
@@ -1,65 +1,48 @@
-import { useState, useEffect, useMemo, useRef, useLayoutEffect } from 'react';
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { useGetAccountInfo, useGetLoginInfo } from '@elrondnetwork/dapp-core';
 import BoltIcon from '@mui/icons-material/Bolt';
 import { Box } from '@mui/material';
-import MenuItem from '@mui/material/MenuItem';
 import Typography from '@mui/material/Typography';
-import { useTheme } from 'styled-components';
 import { AccountButton } from 'src/components/Theme/StyledComponents';
-import Unlock from 'src/pages/Unlock';
 import addressShorthand from 'src/helpers/addressShorthand';
 import { useDispatch, useSelector } from 'react-redux';
-import { isLoginModalOpenSelector } from 'src/redux/selectors/modalsSelector';
-import { setIsLoginModalOpen } from 'src/redux/slices/modalsSlice';
 import { usePrevious } from 'src/utils/usePrevious';
-import { ConnectDropdown } from '../navbar-style';
-import ConnectedAccount from '../ConnectedAccount';
+import { ProposalsTypes } from 'src/types/Proposals';
+import { setProposeModalSelectedOption } from 'src/redux/slices/modalsSlice';
+import { proposeModalSelectedOptionSelector } from 'src/redux/selectors/modalsSelector';
 
 function Account() {
-  const theme: any = useTheme();
   const { address } = useGetAccountInfo();
   const { isLoggedIn, loginMethod } = useGetLoginInfo();
   const accountButtonRef = useRef<HTMLButtonElement | null>(null);
   const [walletAddress, setWalletAddress] = useState('');
-  const [dropdownOpacity, setDropdownOpacity] = useState(1);
 
   useEffect(() => {
     setWalletAddress(addressShorthand(address));
   }, [isLoggedIn, address]);
 
   const [isMainButtonActive, setIsMainButtonActive] = useState(false);
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const isLoginModalOpen = useSelector<boolean>(isLoginModalOpenSelector);
-  const open = Boolean(anchorEl);
   const dispatch = useDispatch();
   const wasLoggedIn = usePrevious(isLoggedIn, false);
 
-  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-    setDropdownOpacity(1);
+  const handleClick = () => {
     setIsMainButtonActive(true);
-    setAnchorEl(event.currentTarget);
+    dispatch(
+      setProposeModalSelectedOption({
+        option: ProposalsTypes.connect_wallet,
+      }),
+    );
   };
 
-  const handleClose = () => {
-    setAnchorEl(null);
+  const handleClose = useCallback(() => {
     setIsMainButtonActive(false);
-    dispatch(setIsLoginModalOpen(false));
-  };
-
-  useEffect(() => {
-    if (isLoginModalOpen) {
-      accountButtonRef.current?.click();
-      return;
-    }
-
-    handleClose();
-  }, [isLoginModalOpen]);
+  }, []);
 
   useEffect(() => {
     if (!wasLoggedIn && loginMethod) {
       handleClose();
     }
-  }, [loginMethod, wasLoggedIn]);
+  }, [handleClose, loginMethod, wasLoggedIn]);
 
   const MAIN_BUTTON_VARIABLE_STYLE = useMemo(
     () => ({
@@ -68,30 +51,15 @@ function Account() {
     }), [isMainButtonActive],
   );
 
-  useLayoutEffect(() => {
-    if (dropdownOpacity === 0) {
-      setIsMainButtonActive(false);
-      const dialogDiv = document.querySelector('div[role=dialog]');
-      const ledgerDiv = document.querySelector('div.ledger-login');
-      if (dialogDiv && !ledgerDiv) {
-        dialogDiv.addEventListener('blur', () => {
-          handleClose();
-        });
-      }
-      if (ledgerDiv) {
-        ledgerDiv.addEventListener('blur', () => {
-          setTimeout(() => {
-            const ledgerDivLater = document.querySelector('div.ledger-login');
-            if (!ledgerDivLater) { handleClose(); }
-          }, 300);
-        });
-      }
-    }
-  }, [dropdownOpacity]);
+  const selectedOption = useSelector(proposeModalSelectedOptionSelector);
+
+  useEffect(() => {
+    setIsMainButtonActive(selectedOption === ProposalsTypes.connect_wallet);
+  }, [selectedOption]);
 
   return (
     <div className="mr-2">
-      <Box>
+      <Box display="flex" gap={2}>
         <AccountButton
           variant="outlined"
           onClick={handleClick}
@@ -108,45 +76,6 @@ function Account() {
           </Box>
         </AccountButton>
       </Box>
-      <ConnectDropdown
-        anchorEl={anchorEl}
-        PaperProps={{
-          sx: {
-            borderRadius: '10px',
-            boxShadow: '0px 8px 24px rgba(76, 47, 252, 0.13)',
-            backgroundColor: theme.palette.background.safeOptions.main,
-          },
-        }}
-        open={open}
-        sx={{
-          height: dropdownOpacity === 0 ? '0' : 'auto',
-          opacity: dropdownOpacity,
-          overflow: dropdownOpacity === 0 ? 'hidden' : 'auto',
-        }}
-        onClose={handleClose}
-        onClick={() => {
-          setDropdownOpacity(0);
-        }}
-      >
-        {isLoggedIn ? (
-          <Box sx={{ width: '350px' }}>
-            <ConnectedAccount />
-          </Box>
-        ) : (
-          <MenuItem
-            sx={{
-              padding: '0',
-              '&:hover': {
-                backgroundColor: 'transparent',
-              },
-            }}
-          >
-            <Unlock />
-          </MenuItem>
-        )}
-
-      </ConnectDropdown>
-
     </div>
   );
 }

--- a/src/components/Layout/Navbar/ConnectedAccount/index.tsx
+++ b/src/components/Layout/Navbar/ConnectedAccount/index.tsx
@@ -1,13 +1,11 @@
 import { logout, useGetAccountInfo, useGetLoginInfo } from '@elrondnetwork/dapp-core';
 import SearchIcon from '@mui/icons-material/Search';
 import LogoutIcon from '@mui/icons-material/Logout';
-import { Box, Typography } from '@mui/material';
+import { Box, Grid, useMediaQuery } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import { toSvg } from 'jdenticon';
-import addressShorthand from 'src/helpers/addressShorthand';
 import { accessTokenServices } from 'src/services/accessTokenServices';
 import routeNames from 'src/routes/routeNames';
-
 import { network } from 'src/config';
 import { useEffect, useState } from 'react';
 import { setCurrentMultisigContract } from 'src/redux/slices/multisigContractsSlice';
@@ -15,6 +13,8 @@ import { useDispatch, useSelector } from 'react-redux';
 import { setMultisigBalance, setOrganizationTokens, setTokenTableRows } from 'src/redux/slices/accountGeneralInfoSlice';
 import CopyButton from 'src/components/CopyButton';
 import { currentMultisigContractSelector } from 'src/redux/selectors/multisigContractsSelectors';
+import { setProposeModalSelectedOption } from 'src/redux/slices/modalsSlice';
+import { truncateInTheMiddle } from 'src/utils/addressUtils';
 import {
   ConnectItems,
   DisconnectButton,
@@ -38,6 +38,7 @@ const ConnectedAccount = () => {
       dispatch(setTokenTableRows([]));
       dispatch(setOrganizationTokens([]));
       dispatch(setCurrentMultisigContract(''));
+      dispatch(setProposeModalSelectedOption(null));
     });
   };
 
@@ -48,30 +49,39 @@ const ConnectedAccount = () => {
   const { isLoggedIn } = useGetLoginInfo();
 
   const [walletAddress, setWalletAddress] = useState('');
+  const width480 = useMediaQuery('(min-width:600px)');
+  const width415 = useMediaQuery('(min-width:415px)');
 
   useEffect(() => {
-    setWalletAddress(addressShorthand(address));
-  }, [address, isLoggedIn]);
+    // eslint-disable-next-line no-nested-ternary
+    setWalletAddress(truncateInTheMiddle(address, width480 ? 12 : width415 ? 9 : 8));
+  }, [address, isLoggedIn, width415, width480]);
 
   return (
     <Box>
-      <Box
-        sx={{ mt: 2, mb: 2 }}
-        className="d-flex justify-content-center align-items-center"
+      <Grid
+        container
+        width={'100%'}
+        sx={{
+          my: 2,
+          justifyContent: !width415 ? 'center !important' : 'space-between !important',
+        }}
+        className="d-flex justify-content-between align-items-center"
+        gap={1}
       >
-        <Box
-          sx={{ borderRadius: '10px', overflow: 'hidden' }}
-          dangerouslySetInnerHTML={{
-            __html: toSvg(address, 98, { padding: 0 }),
-          }}
-        />
-        <Box sx={{ ml: 2 }}>
+        <Grid item sx={{ marginBottom: width415 ? '0' : '1rem' }}>
+          <Box
+            sx={{ borderRadius: '10px', overflow: 'hidden' }}
+            dangerouslySetInnerHTML={{
+              __html: toSvg(address, width415 ? 98 : 165, { padding: 0 }),
+            }}
+          />
+        </Grid>
+        <Grid xs={width415 ? 8 : 12} sm={8} item>
           <ConnectItems className="d-flex justify-content-between" sx={{ p: 1 }}>
-            <Typography sx={{ mr: 1, ml: 1 }}>
-              {addressShorthand(walletAddress)}
-            </Typography>
+            {walletAddress}
             <Box className="d-flex">
-              <Box sx={{ mr: 1 }}>
+              <Box flex={4} sx={{ mr: 1 }}>
                 <CopyButton text={currentContract?.address} link={Styled.CopyIconLinkConnectedAccount} />
               </Box>
               <Box sx={{ mr: 1 }}>
@@ -88,15 +98,15 @@ const ConnectedAccount = () => {
           <DisconnectButton
             variant="outlined"
             onClick={onDisconnectClick}
-            sx={{ margin: 'auto', mt: 2, mb: 2 }}
+            sx={{ margin: 'auto', mt: 2, mb: 2, width: '100%' }}
           >
             <div>
               <LogoutIcon sx={{ mr: 1 }} />
-              <span>Disconnect Wallet</span>
+              <span>{'Disconnect Wallet'}</span>
             </div>
           </DisconnectButton>
-        </Box>
-      </Box>
+        </Grid>
+      </Grid>
     </Box>
   );
 };

--- a/src/components/Layout/Navbar/MenuItems/MenuLink.tsx
+++ b/src/components/Layout/Navbar/MenuItems/MenuLink.tsx
@@ -1,7 +1,8 @@
 import { useDispatch } from 'react-redux';
 import { Link, useLocation } from 'react-router-dom';
 import { Text } from 'src/components/StyledComponents/StyledComponents';
-import { setIsLoginModalOpen } from 'src/redux/slices/modalsSlice';
+import { setProposeModalSelectedOption } from 'src/redux/slices/modalsSlice';
+import { ProposalsTypes } from 'src/types/Proposals';
 import * as Styled from './styled';
 
 interface IMenuLinkProps {
@@ -25,7 +26,7 @@ const MenuLink = ({ menuItem, shouldRequireLogin }: IMenuLinkProps) => {
       key={menuItem.id}
       to={menuItem.link}
       onClick={() => {
-        if (shouldRequireLogin) { dispatch(setIsLoginModalOpen(true)); }
+        if (shouldRequireLogin) { dispatch(setProposeModalSelectedOption({ option: ProposalsTypes.connect_wallet })); }
       }}
       className={
         locationString === menuItem.link

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -22,6 +22,7 @@ import { ElrondApiProvider } from 'src/services/ElrondApiNetworkProvider';
 import { Nav } from 'react-bootstrap';
 import { useNavigate } from 'react-router-dom';
 import { currentMultisigContractSelector } from 'src/redux/selectors/multisigContractsSelectors';
+import { setProposeModalSelectedOption } from 'src/redux/slices/modalsSlice';
 import { TokenWrapper } from '../TokenWrapper';
 import PageBreadcrumbs from './Breadcrumb';
 import ModalLayer from './Modal';
@@ -56,6 +57,7 @@ function Layout({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     if (isLoggedIn) {
+      dispatch(setProposeModalSelectedOption(null));
       (async function getContracts() {
         await refreshAccount();
         await fetchAccountData();

--- a/src/components/Theme/StyledComponents.jsx
+++ b/src/components/Theme/StyledComponents.jsx
@@ -473,7 +473,7 @@ export const ModalContainer = styled(Modal)`
 export const PerformModal = styled(Box)`
 &&& {
   background-color: ${(props) => props.theme.palette.background.secondary};
-  padding: 21px 40px 40px;
+  padding: 21px 40px;
 }
 `;
 

--- a/src/pages/Dashboard/DashboardPage.tsx
+++ b/src/pages/Dashboard/DashboardPage.tsx
@@ -20,7 +20,8 @@ import AddRoundedIcon from '@mui/icons-material/AddRounded';
 import FileDownloadRoundedIcon from '@mui/icons-material/FileDownloadRounded';
 import { Text } from 'src/components/StyledComponents/StyledComponents';
 import { dAppName } from 'src/config';
-import { setIsLoginModalOpen } from 'src/redux/slices/modalsSlice';
+import { setProposeModalSelectedOption } from 'src/redux/slices/modalsSlice';
+import { ProposalsTypes } from 'src/types/Proposals';
 import AddMultisigModal from './AddMultisigModal';
 import DeployStepsModal from './DeployMultisigModal';
 import { useOrganizationInfoContext } from '../Organization/OrganizationInfoContextProvider';
@@ -65,7 +66,7 @@ function Dashboard() {
       setShowDeployMultisigModal(true);
       return;
     }
-    dispatch(setIsLoginModalOpen(true));
+    dispatch(setProposeModalSelectedOption({ option: ProposalsTypes.connect_wallet }));
   }, [dispatch, isLoggedIn]);
 
   const handleAddExistingSafeButtonClick = useCallback(() => {
@@ -73,7 +74,7 @@ function Dashboard() {
       setShowAddMultisigModal(true);
       return;
     }
-    dispatch(setIsLoginModalOpen(true));
+    dispatch(setProposeModalSelectedOption({ option: ProposalsTypes.connect_wallet }));
   }, [dispatch, isLoggedIn]);
 
   const deployButton = (

--- a/src/pages/MultisigDetails/ProposeModal/ProposeModal.tsx
+++ b/src/pages/MultisigDetails/ProposeModal/ProposeModal.tsx
@@ -16,6 +16,9 @@ import { ProposalsTypes, SelectedOptionType } from 'src/types/Proposals';
 import { MainButton, MainButtonNoShadow } from 'src/components/Theme/StyledComponents';
 import { Box } from '@mui/material';
 import ModalCardTitle from 'src/components/Layout/Modal/ModalCardTitle';
+import Unlock from 'src/pages/Unlock';
+import { getIsLoggedIn } from '@elrondnetwork/dapp-core';
+import ConnectedAccount from 'src/components/Layout/Navbar/ConnectedAccount';
 import EditOwner from './EditOwner';
 import ProposeChangeQuorum from './ProposeChangeQuorum';
 import ProposeInputAddress from './ProposeInputAddress';
@@ -99,6 +102,7 @@ function ProposeModal({ selectedOption }: ProposeModalPropsType) {
   }
   // eslint-disable-next-line consistent-return
   const getModalContent = () => {
+    const isLoggedIn = getIsLoggedIn();
     switch (selectedOption?.option) {
       case ProposalsTypes.change_quorum: {
         return (
@@ -116,6 +120,12 @@ function ProposeModal({ selectedOption }: ProposeModalPropsType) {
             handleParamsChange={handleAddressParamChange}
           />
         );
+      case ProposalsTypes.connect_wallet:
+      {
+        if (isLoggedIn) return <Box width="100%"><ConnectedAccount /></Box>;
+        return <Unlock />;
+      }
+
       case ProposalsTypes.remove_user:
         return (
           <ProposeRemoveUser
@@ -168,9 +178,35 @@ function ProposeModal({ selectedOption }: ProposeModalPropsType) {
       case (ProposalsTypes.remove_user): {
         return 'Remove Member';
       }
+      case (ProposalsTypes.connect_wallet): {
+        const isLoggedIn = getIsLoggedIn();
+        if (isLoggedIn) return 'Account Details';
+        return 'Connect Wallet';
+      }
       default:
         return 'Add member';
     }
+  };
+
+  const getModalActions = () => {
+    if (selectedOption.option === ProposalsTypes.connect_wallet) return <div />;
+    return (
+      <Box className="modal-action-btns" sx={{ mt: '24px !important' }}>
+        <MainButton
+          onClick={handleClose}
+          sx={{ boxShadow: 'none !important' }}
+        >
+          {t('Cancel')}
+        </MainButton>
+        <MainButtonNoShadow
+          disabled={submitDisabled}
+          onClick={onProposeClicked}
+          sx={{ gap: '5px !important' }}
+        >
+          {t(getActionButtonText())}
+        </MainButtonNoShadow>
+      </Box>
+    );
   };
 
   return (
@@ -185,26 +221,12 @@ function ProposeModal({ selectedOption }: ProposeModalPropsType) {
       <ModalCardTitle title={getModalTitle()} handleClose={handleClose} />
       <div className="card">
         <Box
-          sx={{ padding: '21px 40px 40px',
+          sx={{ padding: '21px 40px',
             backgroundColor: theme.palette.background.secondary,
             borderRadius: '0 0 10px 10px' }}
         >
           {getModalContent()}
-          <Box className="modal-action-btns" sx={{ mt: '24px !important' }}>
-            <MainButton
-              onClick={handleClose}
-              sx={{ boxShadow: 'none !important' }}
-            >
-              {t('Cancel')}
-            </MainButton>
-            <MainButtonNoShadow
-              disabled={submitDisabled}
-              onClick={onProposeClicked}
-              sx={{ gap: '5px !important' }}
-            >
-              {t(getActionButtonText())}
-            </MainButtonNoShadow>
-          </Box>
+          {getModalActions()}
         </Box>
       </div>
     </Modal>

--- a/src/pages/MultisigDetails/constants.ts
+++ b/src/pages/MultisigDetails/constants.ts
@@ -23,4 +23,5 @@ export const titles = {
   [ProposalsTypes.stake_tokens]: 'Choose a Staking Provider',
   [ProposalsTypes.unstake_tokens]: 'Unstake tokens',
   [ProposalsTypes.withdraw_funds]: 'Withdraw funds',
+  [ProposalsTypes.connect_wallet]: 'Connect Wallet',
 };

--- a/src/redux/selectors/modalsSelector.ts
+++ b/src/redux/selectors/modalsSelector.ts
@@ -28,11 +28,6 @@ export const proposeModalSelectedOptionSelector = createDeepEqualSelector(
   (state) => state.selectedOption,
 );
 
-export const isLoginModalOpenSelector = createDeepEqualSelector(
-  modalsSliceSelector,
-  (state) => state?.loginModal.isOpen,
-);
-
 export const proposeMultiselectModalSelectedOptionSelector =
   createDeepEqualSelector(
     proposeMultiselectModalSelector,

--- a/src/redux/slices/modalsSlice.ts
+++ b/src/redux/slices/modalsSlice.ts
@@ -39,17 +39,12 @@ interface ProposeMultiselectModal {
   selectedOption?: SelectedOptionType;
 }
 
-export interface LoginModal {
-  isOpen: boolean;
-}
-
 export interface ModalsSliceState {
   txSubmittedModal?: TxSubmittedModal;
   notificationModal?: NotificationModal;
   proposeModal: ProposeModal;
   proposeMultiselectModal: ProposeMultiselectModal;
   performActionModal: PerformActionModal;
-  loginModal: LoginModal;
 }
 
 const initialState: ModalsSliceState = {
@@ -64,9 +59,6 @@ const initialState: ModalsSliceState = {
     selectedToken: null,
     selectedNft: null,
     selectedStakingProvider: null,
-  },
-  loginModal: {
-    isOpen: false,
   },
 };
 
@@ -122,12 +114,6 @@ export const modalsSlice = createSlice({
     ) => {
       state.performActionModal.selectedNft = action.payload;
     },
-    setIsLoginModalOpen: (
-      state: ModalsSliceState,
-      action: PayloadAction<boolean>,
-    ) => {
-      state.loginModal.isOpen = action.payload;
-    },
     setSelectedStakingProvider: (
       state: ModalsSliceState,
       action: PayloadAction<any>,
@@ -152,7 +138,6 @@ export const {
   setSelectedTokenToSend,
   setSelectedNftToSend,
   setSelectedStakingProvider,
-  setIsLoginModalOpen,
 } = modalsSlice.actions;
 
 export default modalsSlice.reducer;

--- a/src/types/Proposals.ts
+++ b/src/types/Proposals.ts
@@ -21,6 +21,7 @@ export enum ProposalsTypes {
   'stake_tokens' = 'stake_tokens',
   'unstake_tokens' = 'unstake_tokens',
   'withdraw_funds' = 'withdraw_funds',
+  'connect_wallet' = 'connect_wallet',
 }
 
 export interface RemoveUserOptionType {


### PR DESCRIPTION
Expected results:

- Login modal should now be centered, like the one in Maiar Exchange
- Login button should be active in the background while the login modal is displayed and inactive after closing it
- All login flows should work as they worked before. (Maiar DeFi Wallet, Web Wallet, Ledger, Maiar App)
- All login flows should now be rendered above the login modal (the login modal should remain available after refusing the login with the previously selected method)
- Settings menu entry, create new safe and upload existing safe should now trigger the new login modal, not the old one.
- The login button should be active directly after a logout (until now, the user had to click one more time to make an overlay disappear - this should have been fixed with the new flow)
- The connected account session should be responsive and the design (look + responsiveness) should be validated by Miki.  